### PR TITLE
Add pre-commit hooks functionality.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,10 +27,6 @@ repos:
       - id: check-xml
         always_run: true
 
-      - id: fix-encoding-pragma
-        always_run: true
-        args: [ --remove ]
-
       - id: end-of-file-fixer
         always_run: true
 
@@ -61,3 +57,12 @@ repos:
         args: [ --fix ]
       # Run the formatter.
       - id: ruff-format
+
+  - repo: local
+    hooks:
+    -   id: pydantic-settings-export
+        name: pydantic-settings-export
+        entry: pydantic-settings-export
+        language: python
+        files: \.py$
+        pass_filenames: false

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,10 @@
+- id: pydantic-settings-export
+  name: pydantic-settings-export
+  description: "Export your Pydantic settings to Markdown and .env.example files!"
+  entry: pydantic-settings-export
+  language: python
+  files: \.py$
+  args: [ ]
+  pass_filenames: false
+  additional_dependencies: [ ]
+  stages: [ pre-commit ]

--- a/pydantic_settings_export/cli.py
+++ b/pydantic_settings_export/cli.py
@@ -107,7 +107,7 @@ def main(parse_args: Sequence[str] | None = None):  # noqa: D103
     s.generators = args.generator
     settings = s.settings or [import_settings_from_string(s) for s in args.settings]
     if not settings:
-        parser.exit(0, parser.format_help())
+        parser.exit(1, parser.format_help())
 
     result = Exporter(s).run_all(*settings)
     if result:

--- a/pydantic_settings_export/generators/dotenv.py
+++ b/pydantic_settings_export/generators/dotenv.py
@@ -10,15 +10,13 @@ __all__ = ("DotEnvGenerator",)
 class DotEnvGenerator(AbstractGenerator):
     """The .env example generator."""
 
-    def write_to_files(self, generated_result: str) -> list[Path]:
-        """Write the generated content to files.
+    def file_paths(self) -> list[Path]:
+        """Get the list of files, which need to create/update.
 
-        :param generated_result: The result is to write to files.
-        :return: The list of file paths is written to.
+        :return: The list of files to write.
+        This is used to determine if the files need to be written.
         """
-        file_path = self.settings.root_dir / self.settings.dotenv.name
-        file_path.write_text(generated_result)
-        return [file_path]
+        return [self.settings.root_dir / self.settings.dotenv.name]
 
     def generate_single(self, settings_info: SettingsInfoModel, level=1) -> str:
         """Generate a .env example for a pydantic settings class.

--- a/pydantic_settings_export/generators/markdown.py
+++ b/pydantic_settings_export/generators/markdown.py
@@ -70,11 +70,11 @@ class MarkdownGenerator(AbstractGenerator):
             + "\n\n".join(self.generate_single(s, 2).strip() for s in settings_infos)
         ).strip() + "\n"
 
-    def write_to_files(self, generated_result: str) -> list[Path]:
-        """Write the generated content to files.
+    def file_paths(self) -> list[Path]:
+        """Get the list of files, which need to create/update.
 
-        :param generated_result: The result to write to files.
-        :return: The list of file paths written to.
+        :return: The list of files to write.
+        This is used to determine if the files need to be written.
         """
         file_paths = []
         for d in self.settings.markdown.save_dirs:
@@ -82,5 +82,4 @@ class MarkdownGenerator(AbstractGenerator):
             d.mkdir(parents=True, exist_ok=True)
             p = d / self.settings.markdown.name
             file_paths.append(p)
-            p.write_text(generated_result)
         return file_paths


### PR DESCRIPTION
Closes #4 

* Add pre-commit hooks functionality.
    - Removed `fix-encoding-pragma` hook from the configuration.
    - Introduced `pydantic-settings-export` as a local hook in `.pre-commit-config.yaml`.
    - Created a new entry for `pydantic-settings-export` in `.pre-commit-hooks.yaml`.
    - Changed exit code from 0 to 1 in `cli.py` for better error handling when no settings are found.
    - Refactored `AbstractGenerator` to replace `write_to_files` with `file_paths` method.
    - Updated `DotEnvGenerator` and `MarkdownGenerator` to use the new `file_paths` method.
    - Improved file update logic to avoid unnecessary writes if content hasn't changed.