### PR TITLE
Fix support of multiple settings

### DIFF
--- a/pydantic_settings_export/generators/abstract.py
+++ b/pydantic_settings_export/generators/abstract.py
@@ -52,7 +52,7 @@ class AbstractGenerator(ABC):
         """
 
     @classmethod
-    def run(cls, settings: Settings, settings_info: SettingsInfoModel) -> list[Path]:
+    def run(cls, settings: Settings, *settings_info: SettingsInfoModel) -> list[Path]:
         """Run the generator.
 
         :param settings: The settings for the generator.
@@ -60,7 +60,7 @@ class AbstractGenerator(ABC):
         :return: The list of file paths is written to.
         """
         generator = cls(settings)
-        result = generator.generate(settings_info)
+        result = generator.generate(*settings_info)
         file_paths = generator.file_paths()
         updated_files: list[Path] = []
         for path in file_paths:


### PR DESCRIPTION
Update the `AbstractGenerator.run` method to accept variable-length settings info arguments.

    - Modify the `AbstractGenerator.run` method in `abstract.py` to take multiple `SettingsInfoModel` arguments.
    - Adjust `generate` method call to unpack `settings_info` as arguments.
    
Closes #19 