### PR TITLE
Export settings instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,30 @@ exporter.run_all(MySettings)
 
 This will generate documentation using all available generators. For custom configuration, see our [Wiki][gh-wiki].
 
+### Exporting Instances with actual values
+
+You can pass settings instances instead of classes to export their actual runtime values:
+
+```python
+from pydantic_settings import BaseSettings
+from pydantic_settings_export import Exporter
+
+
+class MySettings(BaseSettings):
+    debug: bool = False
+    api_url: str = "http://localhost"
+
+
+settings = MySettings(debug=True, api_url="https://api.example.com")
+exporter = Exporter()
+exporter.run_all(settings)
+```
+
+When exporting an instance:
+- Default values are shown as comments
+- Actual instance values are shown as active configuration
+- If a value equals its default, no duplication occurs
+
 ## Configuration
 
 Basic configuration in `pyproject.toml`:

--- a/pydantic_settings_export/generators/dotenv.py
+++ b/pydantic_settings_export/generators/dotenv.py
@@ -116,6 +116,14 @@ class DotEnvGenerator(AbstractGenerator[DotEnvSettings]):
         if not field.is_required and not is_optional:
             return None
 
+        # If the field has an actual value (from an instance), show it with the default as comment
+        if field.has_value:
+            lines = []
+            if field.default is not None:
+                lines.append(f"# {field_name}={field.default}  # default")
+            lines.append(f"{field_name}={field.value}")
+            return "\n".join(lines)
+
         # Format optional fields with a comment prefix
         field_string = f"{field_name}="
         if not field.is_required and is_optional:

--- a/pydantic_settings_export/generators/toml.py
+++ b/pydantic_settings_export/generators/toml.py
@@ -204,7 +204,11 @@ class TomlGenerator(AbstractGenerator[TomlSettings]):
         - It has a None default (always commented regardless of comment_defaults)
         - It is required (always commented to force user to provide a value)
         - comment_defaults is True and the field has a default value
+        - BUT NOT if we have an actual value from an instance
         """
+        if field.has_value:
+            return False
+
         if field.default == "null":
             return True
 
@@ -259,7 +263,8 @@ class TomlGenerator(AbstractGenerator[TomlSettings]):
             container.add(comment(line))
 
         if not self._should_comment_field(field):
-            value = json.loads(cast(str, field.default))
+            value_str = field.value if field.has_value else field.default
+            value = json.loads(cast(str, value_str))
             if prefix:
                 key_parts = full_key.split(".")
                 toml_key = key(key_parts)

--- a/tests/test_dotenv.py
+++ b/tests/test_dotenv.py
@@ -1,0 +1,83 @@
+"""Tests for DotEnvGenerator."""
+
+from pydantic import Field
+from pydantic_settings import BaseSettings
+
+from pydantic_settings_export import SettingsInfoModel
+from pydantic_settings_export.generators.dotenv import DotEnvGenerator
+
+
+class SimpleSettings(BaseSettings):
+    """Simple settings for testing."""
+
+    host: str = Field(default="localhost", description="The host")
+    port: int = Field(default=8080, description="The port")
+    debug: bool = Field(default=False, description="Debug mode")
+
+
+def test_dotenv_instance_shows_default_commented_and_value_uncommented() -> None:
+    """Instance should show default commented and value uncommented."""
+    instance = SimpleSettings(host="production.example.com", port=443, debug=True)
+    info = SettingsInfoModel.from_settings_model(instance)
+
+    generator = DotEnvGenerator()
+    result = generator.generate(info)
+
+    expected = """\
+### SimpleSettings
+
+# HOST="localhost"  # default
+HOST="production.example.com"
+# PORT=8080  # default
+PORT=443
+# DEBUG=false  # default
+DEBUG=true
+"""
+    assert result == expected
+
+
+def test_dotenv_instance_same_as_default_behaves_like_class() -> None:
+    """When value equals default, should behave like class (no duplication)."""
+    instance = SimpleSettings()
+    info_instance = SettingsInfoModel.from_settings_model(instance)
+    info_class = SettingsInfoModel.from_settings_model(SimpleSettings)
+
+    generator = DotEnvGenerator()
+    result_instance = generator.generate(info_instance)
+    result_class = generator.generate(info_class)
+
+    assert result_instance == result_class
+
+
+def test_dotenv_nested_instance() -> None:
+    """Nested instances should propagate their values."""
+
+    class Database(BaseSettings):
+        host: str = Field(default="localhost", description="DB host")
+        port: int = Field(default=5432, description="DB port")
+
+    class AppSettings(BaseSettings):
+        debug: bool = Field(default=False, description="Debug mode")
+        database: Database = Field(default_factory=Database)
+
+    db = Database(host="prod-db.example.com", port=5433)
+    instance = AppSettings(debug=True, database=db)
+    info = SettingsInfoModel.from_settings_model(instance)
+
+    generator = DotEnvGenerator()
+    result = generator.generate(info)
+
+    expected = """\
+### AppSettings
+
+# DEBUG=false  # default
+DEBUG=true
+
+### Database
+
+# DATABASE_HOST="localhost"  # default
+DATABASE_HOST="prod-db.example.com"
+# DATABASE_PORT=5432  # default
+DATABASE_PORT=5433
+"""
+    assert result == expected


### PR DESCRIPTION
In addition to settings classes, this PR allows to export settings instances.

The use case it fills is when an application has updated its configuration (changed the descriptions, added fields etc.) and want to offer a way for user to update their configuration file (with the descriptions updated, the new fields added etc.).

(I am still working on the toml generator improvements. I will open a PR after this one is merged)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Export settings instances with actual runtime values, displaying them alongside defaults in configuration files
  * Support for exporting nested settings with actual values in TOML and dotenv formats

* **Documentation**
  * Added guidance on exporting instances with actual values including code examples and behavior explanations

* **Tests**
  * Added comprehensive test coverage for instance value export across dotenv and TOML generators

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->